### PR TITLE
Loosen hard requirement on Card, Deck, and Provable.

### DIFF
--- a/src/Card.php
+++ b/src/Card.php
@@ -185,9 +185,17 @@ class Card implements CardInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Create a Card.
+     *
+     * @param int $faceId
+     *   The Card face value or a provable random roll.
+     * @param int $suitId
+     *   The Card suit value or a provable type.
+     *
+     * @return CardInterface
+     *   The created Card.
      */
-    public static function init(int $faceId, int $suitId = self::TYPE_PROVABLE): Card
+    public static function init(int $faceId, int $suitId = self::TYPE_PROVABLE): CardInterface
     {
         return new static($faceId, $suitId);
     }
@@ -239,9 +247,13 @@ class Card implements CardInterface
     {
         if ($this->isJoker()) {
             return 0;
-        } elseif ($this->isRoyalty()) {
+        }
+
+        if ($this->isRoyalty()) {
             return 10;
-        } elseif ($this->isAce()) {
+        }
+
+        if ($this->isAce()) {
             return 11;
         }
 
@@ -283,7 +295,7 @@ class Card implements CardInterface
     /**
      * {@inheritdoc}
      */
-    public function greaterThan(Card $card, bool $useSuitValue = false): bool
+    public function greaterThan(CardInterface $card, bool $useSuitValue = false): bool
     {
         return $this->compare($card, $useSuitValue) === 1;
     }
@@ -333,7 +345,7 @@ class Card implements CardInterface
     /**
      * {@inheritdoc}
      */
-    public function lessThan(Card $card, bool $useSuitValue = false): bool
+    public function lessThan(CardInterface $card, bool $useSuitValue = false): bool
     {
         return $this->compare($card, $useSuitValue) === -1;
     }
@@ -341,7 +353,7 @@ class Card implements CardInterface
     /**
      * {@inheritdoc}
      */
-    public function equalTo(Card $card, bool $useSuitValue = false): bool
+    public function equalTo(CardInterface $card, bool $useSuitValue = false): bool
     {
         return $this->compare($card, $useSuitValue) === 0;
     }
@@ -349,7 +361,7 @@ class Card implements CardInterface
     /**
      * Compares a Card against this Card for equality.
      *
-     * @param Card $card
+     * @param CardInterface $card
      *   The Card to compare against.
      * @param bool $useSuitValue
      *   TRUE to factor in suits when comparing equal Cards.
@@ -357,7 +369,7 @@ class Card implements CardInterface
      * @return int
      *   -1 if the Card is less than, 0 if it is the same, or 1 if it is greater than.
      */
-    protected function compare(Card $card, bool $useSuitValue = false): int
+    protected function compare(CardInterface $card, bool $useSuitValue = false): int
     {
         $comp = $this->rank() <=> $card->rank();
         if ($comp === 0 && $useSuitValue) {

--- a/src/CardInterface.php
+++ b/src/CardInterface.php
@@ -60,22 +60,6 @@ interface CardInterface
     public const TYPE_PROVABLE = -100;
 
     /**
-     * Create a Card.
-     *
-     * @param int $faceId
-     *   The Card face value or a provable random roll.
-     * @param int $suitId
-     *   The Card suit value or a provable type.
-     *
-     * @return Card
-     *   The created Card.
-     */
-    public static function init(
-        int $faceId,
-        int $suitId = self::TYPE_PROVABLE
-    ): Card;
-
-    /**
      * Cast the Card to a usable string.
      *
      * @return string
@@ -152,7 +136,7 @@ interface CardInterface
     /**
      * Compare a Card to this one for higher rank (and suit).
      *
-     * @param Card $card
+     * @param CardInterface $card
      *   The Card to compare ranks against.
      * @param bool $useSuitValue
      *   TRUE to factor suit order into the comparison.
@@ -160,7 +144,7 @@ interface CardInterface
      * @return bool
      *   TRUE if if this Card is higher ranked than the given Card.
      */
-    public function greaterThan(Card $card, bool $useSuitValue = false): bool;
+    public function greaterThan(CardInterface $card, bool $useSuitValue = false): bool;
 
     /**
      * Get the Card's ranking.
@@ -181,7 +165,7 @@ interface CardInterface
     /**
      * Compare a Card to this one for lower rank (and suit).
      *
-     * @param Card $card
+     * @param CardInterface $card
      *   The Card to compare ranks against.
      * @param bool $useSuitValue
      *   TRUE to factor suit order into the comparison.
@@ -189,12 +173,12 @@ interface CardInterface
      * @return bool
      *   TRUE if if this Card is lower ranked than the given Card.
      */
-    public function lessThan(Card $card, bool $useSuitValue = false): bool;
+    public function lessThan(CardInterface $card, bool $useSuitValue = false): bool;
 
     /**
      * Compare a Card to this one for equal rank (and suit).
      *
-     * @param Card $card
+     * @param CardInterface $card
      *   The Card to compare ranks against.
      * @param bool $useSuitValue
      *   TRUE to factor suit order into the comparison.
@@ -202,7 +186,7 @@ interface CardInterface
      * @return bool
      *   TRUE if the cards are the same, FALSE otherwise.
      */
-    public function equalTo(Card $card, bool $useSuitValue = false): bool;
+    public function equalTo(CardInterface $card, bool $useSuitValue = false): bool;
 
     /**
      * Get the original value that was passed in as the face.

--- a/src/Deck.php
+++ b/src/Deck.php
@@ -8,31 +8,36 @@ class Deck
 {
     /**
      * Provable
-     * @var Provable $provable
+     *
+     * @var Provable
      */
     protected $provable;
 
     /**
      * Deck cards
-     * @var array $cards
+     *
+     * @var int[]
      */
     protected $cards = [];
 
     /**
      * Remaining deck cards
-     * @var array $remainingCards
+     *
+     * @var \Gamebetr\Cards\CardInterface[]
      */
     protected $remainingCards = [];
 
     /**
      * Dealt deck cards
-     * @var array $dealtCards
+     *
+     * @var \Gamebetr\Cards\CardInterface[]
      */
     protected $dealtCards = [];
 
     /**
      * Burnt deck cards
-     * @var array $burntCards
+     *
+     * @var \Gamebetr\Cards\CardInterface[]
      */
     protected $burntCards = [];
 
@@ -43,19 +48,48 @@ class Deck
      * @param int $deckCount - amount of card decks
      * @param bool $jokers - include jokers?
      */
-    public function __construct(
-        string $clientSeed = null,
-        string $serverSeed = null,
-        int $deckCount = 1,
-        bool $jokers = false
-    ) {
+    public function __construct(string $clientSeed = null, string $serverSeed = null, int $deckCount = 1, bool $jokers = false) {
         $start = $jokers ? $deckCount * -2 : 0;
         $range = range($start, ($deckCount * 52) - 1);
-        $this->provable = Provable::init($clientSeed, $serverSeed, min($range), max($range), 'shuffle');
+        $this->provable = $this->createProvable($clientSeed, $serverSeed, min($range), max($range), 'shuffle');
         $this->cards = $this->provable->results();
         foreach ($this->cards as $card) {
-            $this->remainingCards[] = Card::init($card);
+            $this->remainingCards[] = $this->getCardFromProvable($card);
         }
+    }
+
+    /**
+   * Get a Provable instance.
+   *
+   * @param string|null $clientSeed
+   *   The client seed.
+   * @param string|null $serverSeed
+   *   The server seed.
+   * @param int $min
+   *   The minimum value.
+   * @param int $max
+   *   The maximum value.
+   * @param string $type
+   *   The type of Provable.
+   *
+   * @return \Gamebetr\Provable\Provable
+   *   A Provable instance.
+   */
+    protected function createProvable(string $clientSeed = null, string $serverSeed = null, int $min = 0, int $max = 0, string $type = 'number') : Provable {
+        return Provable::init($clientSeed, $serverSeed, $min, $max, $type);
+    }
+
+    /**
+     * Get a Card from a provable number.
+     *
+     * @param int $provable
+     *   The provable number.
+     *
+     * @return \Gamebetr\Cards\CardInterface
+     *   A Card.
+     */
+    protected function getCardFromProvable(int $provable) : CardInterface {
+        return Card::init($provable);
     }
 
     /**
@@ -65,55 +99,40 @@ class Deck
      * @param int $deckCount - amount of card decks
      * @param bool $jokers - include jokers?
      */
-    public static function init(
-        string $clientSeed = null,
-        string $serverSeed = null,
-        int $deckCount = 1,
-        bool $jokers = false
-    ) : Deck {
+    public static function init(string $clientSeed = null, string $serverSeed = null, int $deckCount = 1, bool $jokers = false) : Deck {
         return new static($clientSeed, $serverSeed, $deckCount, $jokers);
     }
 
     /**
-     * Get provable
-     * @return Provable
-     */
-    public function getProvable() : Provable
-    {
-        return $this->provable;
-    }
-
-    /**
      * Deal a card
-     * @return Card|null
+     * @return CardInterface|null
      */
-    public function deal() : ?Card
+    public function deal() : ?CardInterface
     {
         if ($card = array_shift($this->remainingCards)) {
             $this->dealtCards[] = $card;
-            return $card;
         }
-        return null;
+        return $card ?? null;
     }
 
     /**
      * Burn a card
      *
-     * @return Card|null
+     * @return CardInterface|null
      *   The burned card (if any).
      */
-    public function burn(): ?Card
+    public function burn(): ?CardInterface
     {
         if ($card = array_shift($this->remainingCards)) {
             $this->burntCards[] = $card;
-            return $card;
         }
-        return null;
+        return $card ?? null;
     }
 
     /**
      * Get original cards
-     * @return array
+     *
+     * @return int[]
      */
     public function getCards() : array
     {
@@ -122,7 +141,8 @@ class Deck
 
     /**
      * Get remaining cards
-     * @return array
+     *
+     * @return \Gamebetr\Cards\CardInterface[]
      */
     public function getRemainingCards() : array
     {
@@ -131,7 +151,8 @@ class Deck
 
     /**
      * Get dealt cards
-     * @return array
+     *
+     * @return \Gamebetr\Cards\CardInterface[]
      */
     public function getDealtCards() : array
     {
@@ -140,10 +161,21 @@ class Deck
 
     /**
      * Get burnt cards
-     * @return array
+     *
+     * @return \Gamebetr\Cards\CardInterface[]
      */
     public function getBurntCards() : array
     {
         return $this->burntCards;
+    }
+
+    /**
+     * Get provable
+     *
+     * @return Provable
+     */
+    public function getProvable() : Provable
+    {
+       return $this->provable;
     }
 }


### PR DESCRIPTION
The library specifically uses `Card` in several places, which prevents classes that extend `Card` or implement `CardInterface` from using the compare methods. These changes swap in `CardInterface` and also enable classes to replace how `Decks` create Cards and Provables without needing to duplicate additional logic.